### PR TITLE
Add method to optionally set a custom class loader; fix deprecated UR…

### DIFF
--- a/metadata-extractor/src/java/nz/govt/natlib/meta/config/Config.java
+++ b/metadata-extractor/src/java/nz/govt/natlib/meta/config/Config.java
@@ -143,6 +143,9 @@ public class Config {
 	private static Config instance;
 
 	private static Config editInstance;
+	
+	// custom ClassLoader; system ClassLoader if none set.
+	private static ClassLoader classLoader;
 
 	private ArrayList configMapping;
 
@@ -259,10 +262,28 @@ public class Config {
 	}
 
 	public synchronized static Config getInstance() {
+		if (classLoader == null) {
+			// If no class loader set use default -- the system class loader.
+			Config.classLoader = ClassLoader.getSystemClassLoader();
+		}
 		if (instance == null) {
 			instance = new Config();
 		}
 		return instance;
+	}
+
+	/**
+	 * Allow for the configuration of a ClassLoader other than the
+	 * default system class loader for loading the Adapter classes
+	 * registered in config.xml.
+	 * 
+	 * @param cl - An alternative, custom class loader.
+	 * @see initAdapters(Node)
+	 */
+	public synchronized static void setClassLoader(final ClassLoader cl) {
+		if (cl != null) {
+			Config.classLoader = cl;
+		}
 	}
 
 	public synchronized static Config getEditInstance(boolean renew) {
@@ -452,7 +473,7 @@ public class Config {
 		// find out where...
 		URL furl = ClassLoader.getSystemResource("saveconfig.xml");
 		// remove spaces - if any...
-		String configPath = URLDecoder.decode(furl.getPath());
+		String configPath = URLDecoder.decode(furl.getPath(), "UTF-8");
 		File configFile = new File(configPath);
 		File backup = new File(configFile.getPath() + ".bak");
 		// backup - if poss
@@ -497,7 +518,7 @@ public class Config {
 			LogManager.getInstance().logMessage(e);
 		}
 		// remove spaces - if any...
-		String configPath = URLDecoder.decode(furl.getPath());
+		String configPath = URLDecoder.decode(furl.getPath(), "UTF-8");
 
 		File configFile = new File(configPath);
 		File backup = new File(configFile.getPath() + ".bak");
@@ -683,7 +704,7 @@ public class Config {
 					DataAdapter adapter = null;
 					try {
 						adapter = (DataAdapter) Class.forName(className, true,
-								ClassLoader.getSystemClassLoader())
+								classLoader)
 								.newInstance();
 						String jarName = map.getNamedItem(JAR_TAG)
 								.getNodeValue();


### PR DESCRIPTION
This proposed change allows for the optional configuration of a custom class loader for loading Adapter classes a registered in config.xml

Config.java currently loads the adapters from config.xml in the method initAdapters(Node node) with the call
adapter = (DataAdapter) Class.forName(className, true,
ClassLoader.getSystemClassLoader());

We wrap the Metadata Extractor application (along with several other tools) within our tool, FITS (File Information Tool Set), http://fitstool.org. Each tool runs within its own thread. In order to avoid conflicts with different versions of 3rd party packages being used by each tool, it’s necessary to use a custom class loader we created to isolate the loading of all classes and auxiliary data files for each tool. The Config.java submitted with this pull request allows for the configuration of a custom class load via a new method
public synchronized static void setClassLoader(final ClassLoader cl)

There is now a static member of the class
private static ClassLoader classLoader;

The existing method
public synchronized static Config getInstance()
loads the system class loader as used in the original code in the initAdapters(Node node) method above unless a custom class loader is assigned.

As a result, all functionality of this class remains exactly the same if used as previously.

The only other change is to change two deprecated method calls to the recommended method.
Old:
String configPath = URLDecoder.decode(furl.getPath());
New:
String configPath = URLDecoder.decode(furl.getPath(), "UTF-8");